### PR TITLE
ignore fields with huphen in pg

### DIFF
--- a/database/comment.go
+++ b/database/comment.go
@@ -45,6 +45,11 @@ func MakeComments(ctx context.Context, sc SchemeCommenter, models ...interface{}
 			}
 
 			columnName, ok := getPgName(fieldType)
+
+			if columnName == "-" {
+				continue
+			}
+
 			if !ok {
 				columnName = hasura.ToSnakeCase(fieldType.Name)
 			}

--- a/database/comment.go
+++ b/database/comment.go
@@ -40,7 +40,7 @@ func MakeComments(ctx context.Context, sc SchemeCommenter, models ...interface{}
 			}
 
 			comment, ok := getComment(fieldType)
-			if !ok {
+			if !ok || comment == "" {
 				continue
 			}
 

--- a/database/comment_test.go
+++ b/database/comment_test.go
@@ -237,3 +237,28 @@ func TestMakeCommentsIgnoreFieldWithPgHyphen(t *testing.T) {
 	// Assert
 	assert.Empty(t, err)
 }
+
+func TestMakeCommentsIgnoreFieldsWithEmptyComment(t *testing.T) {
+	type Ballot struct {
+		//nolint
+		tableName struct{} `pg:"ballots"`
+		Ballot    string   `json:"ballot" comment:""`
+	}
+
+	mockCtrl, mockSC, ctx := initMocks(t)
+	defer mockCtrl.Finish()
+
+	model := Ballot{}
+
+	// Assert prepare
+	mockSC.
+		EXPECT().
+		MakeColumnComment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	// Act
+	err := MakeComments(ctx, mockSC, model)
+
+	// Assert
+	assert.Empty(t, err)
+}

--- a/database/comment_test.go
+++ b/database/comment_test.go
@@ -212,3 +212,28 @@ func TestMakeCommentsWithMultipleModelsByPointers(t *testing.T) {
 	// Assert
 	assert.Empty(t, err)
 }
+
+func TestMakeCommentsIgnoreFieldWithPgHyphen(t *testing.T) {
+	type Ballot struct {
+		//nolint
+		tableName struct{} `pg:"ballots"`
+		Ballot    string   `json:"ballot" pg:"-" comment:"This is field comment"`
+	}
+
+	mockCtrl, mockSC, ctx := initMocks(t)
+	defer mockCtrl.Finish()
+
+	model := Ballot{}
+
+	// Assert prepare
+	mockSC.
+		EXPECT().
+		MakeColumnComment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	// Act
+	err := MakeComments(ctx, mockSC, model)
+
+	// Assert
+	assert.Empty(t, err)
+}


### PR DESCRIPTION
- Added unit test for case with hyphen in pg name.
- Updated logic of MakeComments to ignore fields with hyphen in pg name.
- Added unit test TestMakeCommentsIgnoreFieldsWithEmptyComment.
- Ignore emty comment in MakeComments.
