### PR TITLE
GO 80 refine MakeComments with struct composition

### DIFF
--- a/database/comment.go
+++ b/database/comment.go
@@ -67,6 +67,14 @@ func makeEmbeddedComments(ctx context.Context, sc SchemeCommenter, tableName str
 	for i := 0; i < t.NumField(); i++ {
 		fieldType := t.Field(i)
 
+		if fieldType.Anonymous {
+			if err := makeEmbeddedComments(ctx, sc, tableName, fieldType.Type); err != nil {
+				return err
+			}
+
+			continue
+		}
+
 		if fieldType.Name == "tableName" {
 			return errors.New("Embedded type must not have tableName field.")
 		}

--- a/database/comment_test.go
+++ b/database/comment_test.go
@@ -357,3 +357,72 @@ func TestMakeCommentsWithStructCompositionAndCorrectOrder(t *testing.T) {
 	// Assert
 	assert.Empty(t, err)
 }
+
+func TestMakeCommentsWithDeepStructComposition(t *testing.T) {
+	type CreatedMetadata struct {
+		CreatedAt int64 `json:"-" comment:"Date of creation in seconds since UNIX epoch."`
+	}
+
+	type UpdatedMetadata struct {
+		CreatedMetadata
+		UpdatedAt int64 `json:"-" comment:"Date of last update in seconds since UNIX epoch."`
+	}
+
+	type Operation struct {
+		UpdatedMetadata
+		Network string `json:"network" pg:",pk" comment:"Identifies belonging network."`
+	}
+
+	type Ballot struct {
+		//nolint
+		tableName struct{} `pg:"ballots" comment:"This multiple table name comment"`
+		Operation
+		Ballot string `json:"ballot" comment:"This is multiple field comment"`
+	}
+
+	mockCtrl, mockSC, ctx := initMocks(t)
+	defer mockCtrl.Finish()
+
+	model := Ballot{}
+
+	// Assert prepare
+	tableNameCall := mockSC.
+		EXPECT().
+		MakeTableComment(ctx, "ballots", "This multiple table name comment").
+		Times(1).
+		Return(nil)
+
+	createdAtCall := mockSC.
+		EXPECT().
+		MakeColumnComment(ctx, "ballots", "created_at", "Date of creation in seconds since UNIX epoch.").
+		After(tableNameCall).
+		Times(1).
+		Return(nil)
+
+	updatedAtCall := mockSC.
+		EXPECT().
+		MakeColumnComment(ctx, "ballots", "updated_at", "Date of last update in seconds since UNIX epoch.").
+		After(createdAtCall).
+		Times(1).
+		Return(nil)
+
+	networkCall := mockSC.
+		EXPECT().
+		MakeColumnComment(ctx, "ballots", "network", "Identifies belonging network.").
+		After(updatedAtCall).
+		Times(1).
+		Return(nil)
+
+	mockSC.
+		EXPECT().
+		MakeColumnComment(ctx, "ballots", "ballot", "This is multiple field comment").
+		After(networkCall).
+		Times(1).
+		Return(nil)
+
+	// Act
+	err := MakeComments(ctx, mockSC, model)
+
+	// Assert
+	assert.Empty(t, err)
+}


### PR DESCRIPTION
- Added unit test for MakeComments on composed struct.
- MakeComments refined with support of Anonymous embedded types in struct.
- Refactor MakeComments with moving field commenting logic to separate method.
- Added TestMakeCommentsWithDeepStructComposition test.
- Updated logic makeEmbeddedComments with support of deep embedding of struct composition.
- Added TestMakeCommentsWithStructCompositionErrorOnEmbeddedTableName test.
